### PR TITLE
fixing parsedUrl reuse

### DIFF
--- a/pkg/acr/projectapi.go
+++ b/pkg/acr/projectapi.go
@@ -89,8 +89,9 @@ func (s *registry) do(req *http.Request) (*http.Response, error) {
 }
 
 func (p *projectAPI) List() ([]globalregistry.Project, error) {
-	p.reg.parsedUrl.Path = path
-	req, err := http.NewRequest(http.MethodGet, p.reg.parsedUrl.String(), nil)
+	url := *p.reg.parsedUrl
+	url.Path = path
+	req, err := http.NewRequest(http.MethodGet, url.String(), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/harbor/members.go
+++ b/pkg/harbor/members.go
@@ -113,10 +113,10 @@ type projectMemberRequestBody struct {
 }
 
 func (p *projectAPI) getMembers(projectID int) ([]*projectMemberEntity, error) {
-	// FIX: thread unsafe handling of parsedUrl
-	p.reg.parsedUrl.Path = fmt.Sprintf("%s/%d/members", path, projectID)
-	p.reg.logger.V(1).Info("creating new request", "parsedUrl", p.reg.parsedUrl.String())
-	req, err := http.NewRequest(http.MethodGet, p.reg.parsedUrl.String(), nil)
+	url := *p.reg.parsedUrl
+	url.Path = fmt.Sprintf("%s/%d/members", path, projectID)
+	p.reg.logger.V(1).Info("creating new request", "url", url.String())
+	req, err := http.NewRequest(http.MethodGet, url.String(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -155,14 +155,14 @@ func (p *projectAPI) getMembers(projectID int) ([]*projectMemberEntity, error) {
 }
 
 func (p *projectAPI) createProjectMember(projectID int, projectMember *projectMemberRequestBody) (int, error) {
-	// FIX: thread unsafe handling of parsedUrl
-	p.reg.parsedUrl.Path = fmt.Sprintf("%s/%d/members", path, projectID)
+	url := *p.reg.parsedUrl
+	url.Path = fmt.Sprintf("%s/%d/members", path, projectID)
 	reqBodyBuf := bytes.NewBuffer(nil)
 	err := json.NewEncoder(reqBodyBuf).Encode(projectMember)
 	if err != nil {
 		return 0, err
 	}
-	req, err := http.NewRequest(http.MethodPost, p.reg.parsedUrl.String(), reqBodyBuf)
+	req, err := http.NewRequest(http.MethodPost, url.String(), reqBodyBuf)
 	if err != nil {
 		return 0, err
 	}
@@ -193,10 +193,10 @@ func (p *projectAPI) createProjectMember(projectID int, projectMember *projectMe
 }
 
 func (p *projectAPI) deleteProjectMember(projectID int, memberId int) error {
-	// FIX: thread unsafe handling of parsedUrl
-	p.reg.parsedUrl.Path = fmt.Sprintf("%s/%d/members/%d", path, projectID, memberId)
-	p.reg.logger.V(1).Info("creating new request", "parsedUrl", p.reg.parsedUrl.String())
-	req, err := http.NewRequest(http.MethodDelete, p.reg.parsedUrl.String(), nil)
+	url := *p.reg.parsedUrl
+	url.Path = fmt.Sprintf("%s/%d/members/%d", path, projectID, memberId)
+	p.reg.logger.V(1).Info("creating new request", "url", url.String())
+	req, err := http.NewRequest(http.MethodDelete, url.String(), nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/harbor/projectapi.go
+++ b/pkg/harbor/projectapi.go
@@ -98,9 +98,9 @@ func (p *projectAPI) GetByName(name string) (globalregistry.Project, error) {
 }
 
 func (p *projectAPI) List() ([]globalregistry.Project, error) {
-	// FIX: thread unsafe handling of parsedUrl
-	p.reg.parsedUrl.Path = path
-	req, err := http.NewRequest(http.MethodGet, p.reg.parsedUrl.String(), nil)
+	url := *p.reg.parsedUrl
+	url.Path = path
+	req, err := http.NewRequest(http.MethodGet, url.String(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -144,8 +144,8 @@ func (p *projectAPI) Create(name string) (globalregistry.Project, error) {
 		Name: name,
 	}
 
-	// FIX: thread unsafe handling of parsedUrl
-	p.reg.parsedUrl.Path = path
+	url := *p.reg.parsedUrl
+	url.Path = path
 	reqBodyBuf := bytes.NewBuffer(nil)
 	err := json.NewEncoder(reqBodyBuf).Encode(&projectCreateReqBody{
 		Name: proj.Name,
@@ -153,7 +153,7 @@ func (p *projectAPI) Create(name string) (globalregistry.Project, error) {
 	if err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequest(http.MethodPost, p.reg.parsedUrl.String(), reqBodyBuf)
+	req, err := http.NewRequest(http.MethodPost, url.String(), reqBodyBuf)
 	if err != nil {
 		return nil, err
 	}
@@ -205,10 +205,10 @@ func (p *projectAPI) Create(name string) (globalregistry.Project, error) {
 }
 
 func (p *projectAPI) delete(id int) error {
-	// FIX: thread unsafe handling of parsedUrl
-	p.reg.parsedUrl.Path = fmt.Sprintf("%s/%d", path, id)
-	p.reg.logger.V(1).Info("creating new request", "parsedUrl", p.reg.parsedUrl.String())
-	req, err := http.NewRequest(http.MethodDelete, p.reg.parsedUrl.String(), nil)
+	url := *p.reg.parsedUrl
+	url.Path = fmt.Sprintf("%s/%d", path, id)
+	p.reg.logger.V(1).Info("creating new request", "url", url.String())
+	req, err := http.NewRequest(http.MethodDelete, url.String(), nil)
 	if err != nil {
 		return err
 	}
@@ -243,9 +243,9 @@ func (prrb *projectRepositoryRespBody) Delete() error {
 }
 
 func (p *projectAPI) listProjectRepositories(proj *project) ([]globalregistry.Repository, error) {
-	// FIX: thread unsafe handling of parsedUrl
-	p.reg.parsedUrl.Path = fmt.Sprintf("%s/%s/repositories", path, proj.Name)
-	req, err := http.NewRequest(http.MethodGet, p.reg.parsedUrl.String(), nil)
+	url := *p.reg.parsedUrl
+	url.Path = fmt.Sprintf("%s/%s/repositories", path, proj.Name)
+	req, err := http.NewRequest(http.MethodGet, url.String(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -279,9 +279,9 @@ func (p *projectAPI) listProjectRepositories(proj *project) ([]globalregistry.Re
 }
 
 func (p *projectAPI) deleteProjectRepository(proj *project, repo globalregistry.Repository) error {
-	// FIX: thread unsafe handling of parsedUrl
-	p.reg.parsedUrl.Path = fmt.Sprintf("%s/%s/repositories/%s", path, proj.Name, repo.GetName())
-	req, err := http.NewRequest(http.MethodDelete, p.reg.parsedUrl.String(), nil)
+	url := *p.reg.parsedUrl
+	url.Path = fmt.Sprintf("%s/%s/repositories/%s", path, proj.Name, repo.GetName())
+	req, err := http.NewRequest(http.MethodDelete, url.String(), nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/harbor/remoteregistries.go
+++ b/pkg/harbor/remoteregistries.go
@@ -150,7 +150,7 @@ func (r *remoteRegistries) create(reg globalregistry.RegistryConfig) (*remoteReg
 		return nil, err
 	}
 	r.reg.logger.V(1).Info(reqBodyBuf.String())
-	url := r.reg.parsedUrl
+	url := *r.reg.parsedUrl
 	url.Path = registriesPath
 	req, err := http.NewRequest(http.MethodPost, url.String(), reqBodyBuf)
 	if err != nil {
@@ -179,10 +179,10 @@ func (r *remoteRegistries) create(reg globalregistry.RegistryConfig) (*remoteReg
 }
 
 func (r *remoteRegistries) list() ([]*remoteRegistryStatus, error) {
-	// FIX: thread unsafe handling of parsedUrl
-	r.reg.parsedUrl.Path = registriesPath
-	r.reg.logger.V(1).Info("creating new request", "parsedUrl", r.reg.parsedUrl.String())
-	req, err := http.NewRequest(http.MethodGet, r.reg.parsedUrl.String(), nil)
+	url := *r.reg.parsedUrl
+	url.Path = registriesPath
+	r.reg.logger.V(1).Info("creating new request", "url", url.String())
+	req, err := http.NewRequest(http.MethodGet, url.String(), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/harbor/replicationapi.go
+++ b/pkg/harbor/replicationapi.go
@@ -41,10 +41,10 @@ func newReplicationAPI(reg *registry) *replicationAPI {
 }
 
 func (r *replicationAPI) List() ([]globalregistry.ReplicationRule, error) {
-	// FIX: thread unsafe handling of parsedUrl
-	r.reg.parsedUrl.Path = replicationPolicyPath
-	r.reg.logger.V(1).Info("creating new request", "parsedUrl", r.reg.parsedUrl.String())
-	req, err := http.NewRequest(http.MethodGet, r.reg.parsedUrl.String(), nil)
+	url := *r.reg.parsedUrl
+	url.Path = replicationPolicyPath
+	r.reg.logger.V(1).Info("creating new request", "url", url.String())
+	req, err := http.NewRequest(http.MethodGet, url.String(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -189,7 +189,7 @@ func (r *replicationAPI) create(project globalregistry.Project, remoteReg global
 		return nil, err
 	}
 	r.reg.logger.V(1).Info(reqBodyBuf.String())
-	url := r.reg.parsedUrl
+	url := *r.reg.parsedUrl
 	url.Path = replicationPolicyPath
 	req, err := http.NewRequest(http.MethodPost, url.String(), reqBodyBuf)
 	if err != nil {
@@ -225,10 +225,10 @@ func (r *replicationAPI) create(project globalregistry.Project, remoteReg global
 }
 
 func (r *replicationAPI) delete(id int) error {
-	// FIX: thread unsafe handling of parsedUrl
-	r.reg.parsedUrl.Path = fmt.Sprintf("%s/%d", replicationPolicyPath, id)
-	r.reg.logger.V(1).Info("creating new request", "parsedUrl", r.reg.parsedUrl.String())
-	req, err := http.NewRequest(http.MethodDelete, r.reg.parsedUrl.String(), nil)
+	url := *r.reg.parsedUrl
+	url.Path = fmt.Sprintf("%s/%d", replicationPolicyPath, id)
+	r.reg.logger.V(1).Info("creating new request", "url", url.String())
+	req, err := http.NewRequest(http.MethodDelete, url.String(), nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/harbor/robots.go
+++ b/pkg/harbor/robots.go
@@ -102,10 +102,10 @@ type robotCreated struct {
 }
 
 func (p *projectAPI) getRobotMembers(projectID int) ([]*robot, error) {
-	// FIX: thread unsafe handling of parsedUrl
-	p.reg.parsedUrl.Path = fmt.Sprintf("%s/%d/robots", path, projectID)
-	p.reg.logger.V(1).Info("creating new request", "parsedUrl", p.reg.parsedUrl.String())
-	req, err := http.NewRequest(http.MethodGet, p.reg.parsedUrl.String(), nil)
+	url := *p.reg.parsedUrl
+	url.Path = fmt.Sprintf("%s/%d/robots", path, projectID)
+	p.reg.logger.V(1).Info("creating new request", "url", url.String())
+	req, err := http.NewRequest(http.MethodGet, url.String(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -138,14 +138,14 @@ func (p *projectAPI) getRobotMembers(projectID int) ([]*robot, error) {
 }
 
 func (p *projectAPI) createProjectRobotMember(robotMember *robot) (*robotCreated, error) {
-	// FIX: thread unsafe handling of parsedUrl
-	p.reg.parsedUrl.Path = "/api/v2.0/robots"
+	url := *p.reg.parsedUrl
+	url.Path = "/api/v2.0/robots"
 	reqBodyBuf := bytes.NewBuffer(nil)
 	err := json.NewEncoder(reqBodyBuf).Encode(robotMember)
 	if err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequest(http.MethodPost, p.reg.parsedUrl.String(), reqBodyBuf)
+	req, err := http.NewRequest(http.MethodPost, url.String(), reqBodyBuf)
 	if err != nil {
 		return nil, err
 	}
@@ -177,10 +177,10 @@ func (p *projectAPI) createProjectRobotMember(robotMember *robot) (*robotCreated
 }
 
 func (p *projectAPI) deleteProjectRobotMember(projectID int, robotMemberID int) error {
-	// FIX: thread unsafe handling of parsedUrl
-	p.reg.parsedUrl.Path = fmt.Sprintf("%s/%d/robots/%d", path, projectID, robotMemberID)
-	p.reg.logger.V(1).Info("creating new request", "parsedUrl", p.reg.parsedUrl.String())
-	req, err := http.NewRequest(http.MethodDelete, p.reg.parsedUrl.String(), nil)
+	url := *p.reg.parsedUrl
+	url.Path = fmt.Sprintf("%s/%d/robots/%d", path, projectID, robotMemberID)
+	p.reg.logger.V(1).Info("creating new request", "url", url.String())
+	req, err := http.NewRequest(http.MethodDelete, url.String(), nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Before this PR the API calls towards a registry server reused the same net.Url value. This will lead to problems when we'll run the API calls in parallel. This PR fixes this issue.