### PR TITLE
Returning unauthorized error for 401 status code

### DIFF
--- a/pkg/acr/projectapi.go
+++ b/pkg/acr/projectapi.go
@@ -82,7 +82,12 @@ func (s *registry) do(req *http.Request) (*http.Response, error) {
 	}
 	resp.Body = buf
 
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+	switch {
+	case resp.StatusCode == 401:
+		// Unauthorized
+		return nil, globalregistry.ErrUnauthorized
+	case resp.StatusCode < 200 || resp.StatusCode >= 300:
+		// Any other error code
 		s.logger.V(-1).Info("HTTP response status code is not OK",
 			"status-code", resp.StatusCode,
 			"resp-body-size", n,

--- a/pkg/config/testdata/test_other_yamls/global-project.yaml
+++ b/pkg/config/testdata/test_other_yamls/global-project.yaml
@@ -12,6 +12,3 @@ spec:
   - name: ci-robot
     type: Robot
     role: PushOnly
-  - name: project-admins
-    type: Group
-    role: ProjectAdmin

--- a/pkg/config/testdata/test_other_yamls/local-project.yaml
+++ b/pkg/config/testdata/test_other_yamls/local-project.yaml
@@ -14,6 +14,3 @@ spec:
   - name: ci-robot
     type: Robot
     role: PushOnly
-  - name: project-admins
-    type: Group
-    role: ProjectAdmin

--- a/pkg/globalregistry/errors.go
+++ b/pkg/globalregistry/errors.go
@@ -32,4 +32,8 @@ var (
 	// ErrAlreadyExists is an error value that indicates that the resource
 	// to be created exists already.
 	ErrAlreadyExists error = errors.New("already exists")
+
+	// ErrUnauthorized is an error value that indicates that the API call
+	// failed due to the API user is not authorized.
+	ErrUnauthorized error = errors.New("unauthorized")
 )

--- a/pkg/harbor/projectapi.go
+++ b/pkg/harbor/projectapi.go
@@ -99,6 +99,9 @@ func (p *projectAPI) GetByName(name string) (globalregistry.Project, error) {
 }
 
 func (p *projectAPI) List() ([]globalregistry.Project, error) {
+	p.reg.logger.V(1).Info("listing projects",
+		"registry", p.reg.GetName(),
+	)
 	url := *p.reg.parsedUrl
 	url.Path = path
 	req, err := http.NewRequest(http.MethodGet, url.String(), nil)
@@ -106,7 +109,6 @@ func (p *projectAPI) List() ([]globalregistry.Project, error) {
 		return nil, err
 	}
 
-	// p.registry.AddBasicAuth(req)
 	req.SetBasicAuth(p.reg.GetUsername(), p.reg.GetPassword())
 
 	resp, err := p.reg.do(req)


### PR DESCRIPTION
The PR introduces a new error type `globalregistry.ErrUnauthorized` that shall be returned when the upstream registry server returns 401.